### PR TITLE
#10 - fix multiple carousel in the same page bug

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,7 +20,7 @@
               :arrowMargin="0" 
               :arrowWidth="20" 
               :arrowHeight="50" 
-              id="carousel">
+              :id="'first-carousel'">
       <template v-slot:left-arrow>
         <MyArrow :navDirection="'left'" :icon="'chevron-left'"/>
       </template>

--- a/src/components/AVCarousel.vue
+++ b/src/components/AVCarousel.vue
@@ -15,7 +15,7 @@
 <script>
   export default {
     name: 'AVCarousel',
-    props: ['itemsLength', 'itemsToShow', 'itemWidth', 'itemHeight', 'itemMarginRight', 'arrowMargin', 'arrowWidth', 'arrowHeight', 'itemsToSlide',],
+    props: ['itemsLength', 'itemsToShow', 'itemWidth', 'itemHeight', 'itemMarginRight', 'arrowMargin', 'arrowWidth', 'arrowHeight', 'itemsToSlide', 'id'],
     data() {
       return {
         // defaults:
@@ -70,7 +70,7 @@
         return Math.min(hiddenItems, this.itemsToSlideData)
       },
       navCallback(offset) {
-        this.$eventBus.$emit('navCallback', offset)
+        this.$eventBus.$emit(`navCallback-${this.id}`, offset)
       },
       navLeft() {
         const itemsToSlide = this.calculateItemsToSlide(this.leftHiddenItems()) // caouse of this calculation using he hidden items we don't need to double check if it can navLeft

--- a/src/components/AVCarouselItem.vue
+++ b/src/components/AVCarouselItem.vue
@@ -7,7 +7,7 @@
 <script>
   export default {
     name: 'AVCarouselItem',
-    props: [],
+    props: ['id'],
     data() {
       return {
         offset: 0,
@@ -19,7 +19,7 @@
       },
     },
     created() {
-      this.$eventBus.$on('navCallback', (offset) => {
+      this.$eventBus.$on(`navCallback-${this.id}`, (offset) => {
         this.navCallback(offset)
       });
     }


### PR DESCRIPTION
Add an carousel `id` to the emitted event in order to prevent multiple carousel in the same page react for the same event.